### PR TITLE
bugfix/reranker initialize bug with model_name

### DIFF
--- a/lrage/rerankers/rerankers_reranker.py
+++ b/lrage/rerankers/rerankers_reranker.py
@@ -31,7 +31,11 @@ class RerankersReranker(Reranker):
             rerankers_args["model_name"] = reranker_path
         if api_key is not None:
             rerankers_args["api_key"] = api_key
-        self.reranker = rerankers.Reranker(**rerankers_args)
+
+        if len(rerankers_args.keys()) == 1:
+            self.reranker =  rerankers.Reranker(rerankers_args["model_type"])
+        else:
+            self.reranker = rerankers.Reranker(**rerankers_args)
 
     def _postprocess_results(self, results: Any) -> QueryContext:
         """


### PR DESCRIPTION
An error occurred during the initialization of Reranker() when only reranker_type was passed without reranker_path. The error message is as follows:

`TypeError: Reranker() missing 1 required positional argument: 'model_name'`

This PR has fixed that error.