### PR TITLE
to save eval config with rag

### DIFF
--- a/lrage/evaluator.py
+++ b/lrage/evaluator.py
@@ -418,6 +418,12 @@ def simple_evaluate(
                 "numpy_seed": numpy_random_seed,
                 "torch_seed": torch_random_seed,
                 "fewshot_seed": fewshot_random_seed,
+                "apply_chat_template": apply_chat_template,
+                "retriever": retriever,
+                "retriever_args": retriever_args,
+                "rerank": rerank,
+                "reranker": reranker,
+                "reranker_args": reranker_args,
             }
         )
         results["git_hash"] = get_git_commit_hash()

--- a/lrage/evaluator.py
+++ b/lrage/evaluator.py
@@ -272,6 +272,7 @@ def simple_evaluate(
             eval_logger.info(
                 f"Initializing {retriever} retriever, with arguments: {simple_parse_args_string(retriever_args)}"
             )
+            retriever_name_log = retriever
             retriever = lrage.api.registry.get_retriever(retriever).create_from_arg_string(
                 retriever_args
             )
@@ -285,6 +286,7 @@ def simple_evaluate(
             eval_logger.info(
                 f"Initializing {reranker} reranker, with arguments: {simple_parse_args_string(reranker_args)}"
             )
+            reranker_name_log = reranker
             reranker = lrage.api.registry.get_reranker(reranker).create_from_arg_string(
                 reranker_args
             )
@@ -419,10 +421,11 @@ def simple_evaluate(
                 "torch_seed": torch_random_seed,
                 "fewshot_seed": fewshot_random_seed,
                 "apply_chat_template": apply_chat_template,
-                "retriever": retriever,
+                "retrieve_docs": retrieve_docs,
+                "retriever": retriever_name_log,
                 "retriever_args": retriever_args,
                 "rerank": rerank,
-                "reranker": reranker,
+                "reranker": reranker_name_log,
                 "reranker_args": reranker_args,
             }
         )


### PR DESCRIPTION
to save eval config with rag

before
<img width="854" alt="스크린샷 2025-03-12 오후 7 17 21" src="https://github.com/user-attachments/assets/0521e49f-d95b-4afb-8a88-07bc06509835" />

after
<img width="734" alt="스크린샷 2025-03-12 오후 7 36 55" src="https://github.com/user-attachments/assets/6bff2b0e-ae82-4c4a-8e69-f08d3b29ab90" />
